### PR TITLE
variants sorted by SKU on admin page

### DIFF
--- a/backend/app/controllers/spree/admin/variants_controller.rb
+++ b/backend/app/controllers/spree/admin/variants_controller.rb
@@ -37,7 +37,7 @@ module Spree
           else
             @collection ||= Variant.only_deleted.where(:product_id => parent.id)
           end
-          @collection
+          @collection.sort_by{ |item| item[:sku] }
         end
 
       private


### PR DESCRIPTION
Pretty small change, just a line. 

-didn't know how to make a separate controller_decorator.rb file for this controller, not sure if this is an anti-pattern.
- Sorts variant collection by SKU.  Not sure if I need to add in error handling, my understanding of Rails is still pretty shaky.
